### PR TITLE
Implements ephemeral group chats

### DIFF
--- a/01statements.rpy
+++ b/01statements.rpy
@@ -1108,6 +1108,7 @@ python early in phone:
         key = None
         icon = None
         chars = [ ]
+        transient = False
         _as = None
         default_statement = None
 
@@ -1144,6 +1145,11 @@ python early in phone:
                             dl.error("character '{}' already given".format(char))
                         chars.append(char)
 
+                    elif p == "transient":
+                        if transient != False:
+                            dl.error("'transient' property already given")
+                        transient = True
+
                     elif p == "as":
                         if _as is not None:
                             dl.error("'as' property already given")
@@ -1163,13 +1169,14 @@ python early in phone:
                 filename, linenumber = l.get_location()
 
                 global _INIT_PHONE_REGISTER_PRIORITY
-                string = "{init} {_as} = phone.group_chat.GroupChat('{name}', {icon}, {key})" \
+                string = "{init} {_as} = phone.group_chat.GroupChat('{name}', {icon}, {key}, transient={transient})" \
                         .format(
                             init=_INIT_PHONE_REGISTER_PRIORITY,
                             _as=_as,
                             name=name,
                             icon=icon,
                             key=key,
+                            transient=transient,
                         )
 
                 lexer = cds_utils.Lexer(

--- a/docs/discussion.md
+++ b/docs/discussion.md
@@ -168,6 +168,9 @@ Expects a displayable. The icon of the group chat.
 - `as`
 Expects a dotted name. The group chat will be saved in the global store under this name (as if the group chat was manually created using the `default` statement).
 
+- `transient`
+Optional. If present, the group chat becomes transient. Transient group chats get cleared once the discussion end.
+
 ---
 ## Example
 
@@ -185,6 +188,7 @@ init phone register:
     define "goofy ahh chat":
         icon phone.config.basedir + "sayori_icon.png" key "goofy"
         add "mc" add "s" as goofy
+        transient
  
     time month 1 day 26 year 2013 hour 14 minute 31
     "mc" "Ah!"

--- a/docs/group_chats.md
+++ b/docs/group_chats.md
@@ -7,10 +7,11 @@
 `class GroupChat(object)`
 The core of the discussion part of this framework.
 
-`def __init__(self, name, icon, key)`
+`def __init__(self, name, icon, key, ephemeral = False)`
 - `name`: a string, the name of the character.
 - `icon`: a displayable.
 - `key`: any hashable object that is not `None`. this must be a unique object proper to this `phone.group_chat.GroupChat` object.
+- `ephemeral`: boolean, determines if the group chat should be cleared once the discussion is over.
 
 Once created, the following fields can be read and safely modified:
 `name`

--- a/docs/group_chats.md
+++ b/docs/group_chats.md
@@ -7,11 +7,11 @@
 `class GroupChat(object)`
 The core of the discussion part of this framework.
 
-`def __init__(self, name, icon, key, ephemeral = False)`
+`def __init__(self, name, icon, key, transient = False)`
 - `name`: a string, the name of the character.
 - `icon`: a displayable.
 - `key`: any hashable object that is not `None`. this must be a unique object proper to this `phone.group_chat.GroupChat` object.
-- `ephemeral`: boolean, determines if the group chat should be cleared once the discussion is over.
+- `transient`: boolean, determines if the group chat should be cleared once the discussion is over.
 
 Once created, the following fields can be read and safely modified:
 `name`
@@ -28,6 +28,9 @@ Removes the `*character*` `char` from this group chat, and removes the group cha
 
 `def number_of_messages_sent(self, char)`
 Returns the number of messages sent by the `*character*` `char`. If `None` is passed, returns the total number of messages sent.
+
+`def clear(self)`
+Clears the GroupChat's history
 
 These objects are *hashable* (their key will be hashed).
 

--- a/phone/apps/discussion/discussion.rpy
+++ b/phone/apps/discussion/discussion.rpy
@@ -49,7 +49,8 @@ init -100 python in phone.discussion:
             
         for key in _group_chat._characters:
             sort_messages(key)
-        
+        if _group_chat.ephemeral:
+            _group_chat.clear_payload()
         _group_chat = None
 
         show_layer_at([], reset=True)

--- a/phone/apps/discussion/discussion.rpy
+++ b/phone/apps/discussion/discussion.rpy
@@ -50,7 +50,7 @@ init -100 python in phone.discussion:
         for key in _group_chat._characters:
             sort_messages(key)
         if _group_chat.ephemeral:
-            _group_chat.clear_payload()
+            _group_chat.clear()
         _group_chat = None
 
         show_layer_at([], reset=True)

--- a/phone/apps/discussion/group_chats.rpy
+++ b/phone/apps/discussion/group_chats.rpy
@@ -13,14 +13,14 @@ init -100 python in phone.group_chat:
     messages_fill_if_lower = 15
 
     class GroupChat(object):    
-        def __init__(self, name, icon, key, ephemeral=False):
+        def __init__(self, name, icon, key, transient=False):
             global _group_chats
             _group_chats[key] = self
 
             self.name = name
             self.icon = icon
             self.date = datetime.datetime(year=1970, month=1, day=1, hour=0, minute=0)
-            self.ephemeral = ephemeral
+            self.transient = transient
 
             self.unread = True
 
@@ -171,7 +171,7 @@ init -100 python in phone.group_chat:
         def __len__(self):
             return len(self._payloads)
 
-        def clear_payload(self):
+        def clear(self):
             self._payloads=[]
 
         def __hash__(self):

--- a/phone/apps/discussion/group_chats.rpy
+++ b/phone/apps/discussion/group_chats.rpy
@@ -13,13 +13,14 @@ init -100 python in phone.group_chat:
     messages_fill_if_lower = 15
 
     class GroupChat(object):    
-        def __init__(self, name, icon, key):
+        def __init__(self, name, icon, key, ephemeral=False):
             global _group_chats
             _group_chats[key] = self
 
             self.name = name
             self.icon = icon
             self.date = datetime.datetime(year=1970, month=1, day=1, hour=0, minute=0)
+            self.ephemeral = ephemeral
 
             self.unread = True
 
@@ -169,6 +170,9 @@ init -100 python in phone.group_chat:
         
         def __len__(self):
             return len(self._payloads)
+
+        def clear_payload(self):
+            self._payloads=[]
 
         def __hash__(self):
             return hash(self.key)


### PR DESCRIPTION
What this PR implements:
Ephemeral conversations that disappear once the discussion ends. It also adds a method to the group chat that allows you to clear it very easily.

Context as of why this exists:
For the purpose of this framework on our project, we really didn't need to maintain the history of previous conversations since the main character only used his phone after a few time skips (weeks, days, or months). So showing a conversation that supposedly happened a month ago next to one that's happening now would kind of break the suspension of disbelief that these characters interact outside the script.
