### PR TITLE
Make self voicing for discussion and calls more usable

### DIFF
--- a/phone/apps/calls/call_screen.rpy
+++ b/phone/apps/calls/call_screen.rpy
@@ -22,8 +22,8 @@ screen _phone_call():
     style_prefix "phone_call"
 
     vbox:
-        text phone.short_name(phone.calls._current_caller.name, 12)
-        add DynamicDisplayable(phone.calls._call_time)
+        text phone.short_name(phone.calls._current_caller.name, 12) alt ""
+        add DynamicDisplayable(phone.calls._call_time) alt ""
 
     frame:            
         add phone.calls._current_caller.icon at _fits(None)
@@ -70,8 +70,8 @@ screen _phone_video_call():
         at Transform(**phone.config.video_call_layer_transform_properties)
     
     vbox:
-        text _("Facetime - [phone.calls._current_caller.name!t]")
-        add DynamicDisplayable(phone.calls._call_time)
+        text _("Facetime - [phone.calls._current_caller.name!t]") alt ""
+        add DynamicDisplayable(phone.calls._call_time) alt ""
     
     use phone_quick_menu_video()
 

--- a/phone/apps/discussion/discussion_screens.rpy
+++ b/phone/apps/discussion/discussion_screens.rpy
@@ -6,7 +6,7 @@ screen phone_discussion():
 
                 hbox:
                     add phone.discussion._group_chat.icon at _fits(36) yalign 0.5
-                    text phone.short_name(phone.discussion._group_chat.name, 9)
+                    text phone.short_name(phone.discussion._group_chat.name, 9) alt ""
 
             use _chat_textbox()
             use _chat_messages()
@@ -78,12 +78,12 @@ screen _chat_textbox():
                                         None
                                     )
                 else:
-                    text _("Type a message.") color "#666"
+                    text _("Type a message.") color "#666" alt ""
                 # ugly ahh
             else:
-                text _("Type a message.") color "#666"
+                text _("Type a message.") color "#666" alt ""
 
-            text _("Send") color "#0094FF" xalign 1.0
+            text _("Send") color "#0094FF" xalign 1.0 alt ""
             
 
 style phone_textbox_frame is empty:
@@ -176,7 +176,13 @@ screen _chat_messages():
 
                         if p.type == phone.discussion._PayloadTypes.TEXT:                        
                             use _chat_message(p):
-                                text p.data
+                                # If this is not the last message or if something's been said rn don't self-voice it
+                                if i != phone.discussion._group_chat.number_of_messages-1 or renpy.get_screen("say"):
+                                    text p.data alt ""
+                                else:
+                                    # Only self-voice the last message sent
+                                    $ sender = __(phone.character.character(p.source).short_name)
+                                    text p.data alt sender + ": " + p.data
 
                         elif p.type == phone.discussion._PayloadTypes.IMAGE:
                             use _chat_message(p):

--- a/phone/apps/discussion/discussion_screens.rpy
+++ b/phone/apps/discussion/discussion_screens.rpy
@@ -181,8 +181,8 @@ screen _chat_messages():
                                     text p.data alt ""
                                 else:
                                     # Only self-voice the last message sent
-                                    $ sender = __(sender.name)
-                                    text p.data alt sender + ": " + p.data
+                                    $ sender_name = __(sender.name)
+                                    text p.data alt sender_name + ": " + p.data
 
                         elif p.type == phone.discussion._PayloadTypes.IMAGE:
                             use _chat_message(p):

--- a/phone/apps/discussion/discussion_screens.rpy
+++ b/phone/apps/discussion/discussion_screens.rpy
@@ -181,7 +181,7 @@ screen _chat_messages():
                                     text p.data alt ""
                                 else:
                                     # Only self-voice the last message sent
-                                    $ sender = __(phone.character.character(p.source).short_name)
+                                    $ sender = __(sender.name)
                                     text p.data alt sender + ": " + p.data
 
                         elif p.type == phone.discussion._PayloadTypes.IMAGE:

--- a/phone/apps/discussion/typing.rpy
+++ b/phone/apps/discussion/typing.rpy
@@ -28,10 +28,12 @@ style phone_typing_frame is phone_messages_frame:
     background phone.character.get_textbox("#f2f2f2")
 
 style phone_typing_text is phone_messages_text:
+    alt ""
     color "#000"
     font "DejaVuSans.ttf"
 
 style phone_typing_istyping is empty:
+    alt ""
     color "#626262"
     outlines [ ]
     size 16


### PR DESCRIPTION
Currently the self-voicing from renpy will attempt to read everything every time, so for each new line of dialogue said it will read the discussion name and every single message in the screen. And for calls it will read the name of whoever is calling you + the time of the call every single time.